### PR TITLE
Save new projects in custom folder (rather than nerd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ configurable using the config file.
 3. (On the first run, configuration file will be generated at
    ~/.omnifocus-trello.yml. Follow to instructions to get a token.)
 
+# Changing the default Folder for trello boards.
+
+By default, the OmniFocus projects created from your trello boards will be stored in a folder called "nerd". To change this, set an environment variable called 'OF_FOLDER'. You can do this by adding the following to your `bash_profile` or similar:
+
+    export OF_FOLDER="My Trello Boards"
+
+Note that this environment variable is used by the [omnifocus](https://github.com/seattlerb/omnifocus) gem, so will apply to any other gems that rely on that.
+
+
 ## Contributing
 
 1. Fork it

--- a/lib/omnifocus/trello/version.rb
+++ b/lib/omnifocus/trello/version.rb
@@ -1,5 +1,5 @@
 require "omnifocus"
 
 module OmniFocus::Trello
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/omnifocus-trello.gemspec
+++ b/omnifocus-trello.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniFocus::Trello::VERSION
 
-  gem.add_dependency "omnifocus", "~> 2.1"
+  gem.add_dependency "omnifocus", "~> 2.2"
 end


### PR DESCRIPTION
Recent change (seattlerb/omnifocus@34aad1d93137e1c161727f363ec84d72cece3eb2) in the omnifocus gem allows the folder to be set through an environment variable. I considered  setting it from an entry in the `.omnifocus-trello.yml` file, but it might override one set by the user. Seems sensible to just add some stuff to the readme.

I've bumped the version number - hope you don't mind.

Fixes #4.
